### PR TITLE
feat: warn on dirty form in settings

### DIFF
--- a/components/NavigationGuard.vue
+++ b/components/NavigationGuard.vue
@@ -1,0 +1,73 @@
+<template>
+	<GPDialog
+		v-model:visible="showNavigationConfirm"
+		header="Unsaved changes"
+	>
+		<div class="flex items-center">
+			<div>
+				<i class="pi pi-exclamation-triangle text-xl text-primary"/>
+			</div>
+			<div class="ml-3">
+				<p>You have unsaved changes. Are you sure you want to leave?</p>
+			</div>
+		</div>
+		<div class="mt-7 text-right">
+			<Button class="mr-2" label="Cancel" severity="secondary" text @click="handleNavigationReject"/>
+			<Button label="Leave" @click="handleNavigationAccept"/>
+		</div>
+	</GPDialog>
+</template>
+
+<script setup lang="ts">
+	import { onMounted, onUnmounted, ref } from 'vue';
+	import { useRouter, type RouteLocationNormalized, type NavigationGuardNext } from 'vue-router';
+
+	declare global {
+		interface Window {
+			hasDirtyForm?: boolean;
+		}
+	}
+
+	const router = useRouter();
+	const showNavigationConfirm = ref(false);
+	const pendingNavigation = ref<NavigationGuardNext | null>(null);
+
+	const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+		if (window.hasDirtyForm) {
+			e.preventDefault();
+			e.returnValue = '';
+		}
+	};
+
+	const handleNavigation = (_to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) => {
+		if (window.hasDirtyForm) {
+			pendingNavigation.value = next;
+			showNavigationConfirm.value = true;
+		} else {
+			next();
+		}
+	};
+
+	const handleNavigationAccept = () => {
+		pendingNavigation.value?.();
+		pendingNavigation.value = null;
+		showNavigationConfirm.value = false;
+		window.hasDirtyForm = false;
+	};
+
+	const handleNavigationReject = () => {
+		pendingNavigation.value?.(false);
+		pendingNavigation.value = null;
+		showNavigationConfirm.value = false;
+	};
+
+	onMounted(() => {
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		router.beforeEach(handleNavigation);
+	});
+
+	onUnmounted(() => {
+		window.removeEventListener('beforeunload', handleBeforeUnload);
+		router.beforeEach(handleNavigation);
+	});
+</script>

--- a/components/NavigationGuard.vue
+++ b/components/NavigationGuard.vue
@@ -19,28 +19,22 @@
 </template>
 
 <script setup lang="ts">
-	import { onMounted, onUnmounted, ref } from 'vue';
 	import { useRouter, type RouteLocationNormalized, type NavigationGuardNext } from 'vue-router';
-
-	declare global {
-		interface Window {
-			hasDirtyForm?: boolean;
-		}
-	}
 
 	const router = useRouter();
 	const showNavigationConfirm = ref(false);
 	const pendingNavigation = ref<NavigationGuardNext | null>(null);
+	const isFormDirty = inject<Ref<boolean>>('form-dirty');
 
 	const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-		if (window.hasDirtyForm) {
+		if (isFormDirty?.value) {
 			e.preventDefault();
 			e.returnValue = '';
 		}
 	};
 
 	const handleNavigation = (_to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) => {
-		if (window.hasDirtyForm) {
+		if (isFormDirty?.value) {
 			pendingNavigation.value = next;
 			showNavigationConfirm.value = true;
 		} else {
@@ -52,7 +46,10 @@
 		pendingNavigation.value?.();
 		pendingNavigation.value = null;
 		showNavigationConfirm.value = false;
-		window.hasDirtyForm = false;
+
+		if (isFormDirty) {
+			isFormDirty.value = false;
+		}
 	};
 
 	const handleNavigationReject = () => {

--- a/components/NavigationGuard.vue
+++ b/components/NavigationGuard.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script setup lang="ts">
+	import { ref, inject, onMounted, onUnmounted, type Ref } from 'vue';
 	import { useRouter, type RouteLocationNormalized, type NavigationGuardNext } from 'vue-router';
 
 	const router = useRouter();
@@ -61,9 +62,13 @@
 	onMounted(() => {
 		window.addEventListener('beforeunload', handleBeforeUnload);
 		router.beforeEach(handleNavigation);
-	});
 
-	onUnmounted(() => {
-		window.removeEventListener('beforeunload', handleBeforeUnload);
+		const removeGuard = router.beforeEach(handleNavigation);
+		const guardRemover = ref(removeGuard);
+
+		onUnmounted(() => {
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+			guardRemover.value();
+		});
 	});
 </script>

--- a/components/NavigationGuard.vue
+++ b/components/NavigationGuard.vue
@@ -19,8 +19,7 @@
 </template>
 
 <script setup lang="ts">
-	import { ref, inject, onMounted, onUnmounted, type Ref } from 'vue';
-	import { useRouter, type RouteLocationNormalized, type NavigationGuardNext } from 'vue-router';
+	import { type RouteLocationNormalized, type NavigationGuardNext } from 'vue-router';
 
 	const router = useRouter();
 	const showNavigationConfirm = ref(false);

--- a/components/NavigationGuard.vue
+++ b/components/NavigationGuard.vue
@@ -65,6 +65,5 @@
 
 	onUnmounted(() => {
 		window.removeEventListener('beforeunload', handleBeforeUnload);
-		router.beforeEach(handleNavigation);
 	});
 </script>

--- a/composables/useFormDirty.ts
+++ b/composables/useFormDirty.ts
@@ -1,0 +1,13 @@
+import { onMounted, watch } from 'vue';
+
+export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boolean) {
+	onMounted(() => {
+		const checkFormDirty = () => {
+			Object.assign(window, { hasDirtyForm: isDirty(initialValue) });
+		};
+
+		checkFormDirty();
+
+		watch(() => isDirty(initialValue), checkFormDirty);
+	});
+}

--- a/composables/useFormDirty.ts
+++ b/composables/useFormDirty.ts
@@ -1,3 +1,5 @@
+import { inject, onMounted, watch, type Ref } from 'vue';
+
 export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boolean) {
 	const isFormDirty = inject<Ref<boolean>>('form-dirty');
 
@@ -12,6 +14,12 @@ export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boole
 
 		checkFormDirty();
 
-		watch(() => isDirty(initialValue), checkFormDirty);
+		watch(() => isDirty(initialValue), () => {
+			checkFormDirty();
+		}, { deep: true });
 	});
+
+	return () => {
+		isFormDirty.value = false;
+	};
 }

--- a/composables/useFormDirty.ts
+++ b/composables/useFormDirty.ts
@@ -1,9 +1,13 @@
-import { onMounted, watch } from 'vue';
-
 export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boolean) {
+	const isFormDirty = inject<Ref<boolean>>('form-dirty');
+
+	if (!isFormDirty) {
+		throw new Error('useFormDirty must be used within a component that provides form-dirty state');
+	}
+
 	onMounted(() => {
 		const checkFormDirty = () => {
-			Object.assign(window, { hasDirtyForm: isDirty(initialValue) });
+			isFormDirty.value = isDirty(initialValue);
 		};
 
 		checkFormDirty();

--- a/composables/useFormDirty.ts
+++ b/composables/useFormDirty.ts
@@ -10,11 +10,9 @@ export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boole
 			isFormDirty.value = isDirty(initialValue);
 		};
 
-		checkFormDirty();
-
 		watch(() => isDirty(initialValue), () => {
 			checkFormDirty();
-		}, { deep: true });
+		}, { deep: true, immediate: true });
 	});
 
 	return () => {

--- a/composables/useFormDirty.ts
+++ b/composables/useFormDirty.ts
@@ -1,5 +1,3 @@
-import { inject, onMounted, watch, type Ref } from 'vue';
-
 export function useFormDirty<T> (initialValue: T, isDirty: (current: T) => boolean) {
 	const isFormDirty = inject<Ref<boolean>>('form-dirty');
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -192,8 +192,6 @@
 <script lang="ts" setup>
 	import { defaults } from 'chart.js';
 	import capitalize from 'lodash/capitalize';
-	import { ref, provide } from 'vue';
-	import NavigationGuard from '~/components/NavigationGuard.vue';
 	import { useNotifications } from '~/composables/useNotifications';
 	import { useAuth } from '~/store/auth';
 	import { formatDateTime } from '~/utils/date-formatters';

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -185,6 +185,7 @@
 				<slot/>
 			</div>
 		</div>
+		<NavigationGuard/>
 	</section>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -192,6 +192,7 @@
 <script lang="ts" setup>
 	import { defaults } from 'chart.js';
 	import capitalize from 'lodash/capitalize';
+	import { ref, provide } from 'vue';
 	import { useNotifications } from '~/composables/useNotifications';
 	import { useAuth } from '~/store/auth';
 	import { formatDateTime } from '~/utils/date-formatters';
@@ -199,6 +200,9 @@
 	const auth = useAuth();
 	const { user } = storeToRefs(auth);
 	const { headerNotifications, inboxNotificationIds, markNotificationsAsRead, markAllNotificationsAsRead, updateHeaderNotifications } = useNotifications();
+
+	const isFormDirty = ref(false);
+	provide('form-dirty', isFormDirty);
 
 	// NOTIFICATIONS
 	const notificationsPanel = ref();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -193,6 +193,7 @@
 	import { defaults } from 'chart.js';
 	import capitalize from 'lodash/capitalize';
 	import { ref, provide } from 'vue';
+	import NavigationGuard from '~/components/NavigationGuard.vue';
 	import { useNotifications } from '~/composables/useNotifications';
 	import { useAuth } from '~/store/auth';
 	import { formatDateTime } from '~/utils/date-formatters';

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -182,6 +182,7 @@
 
 <script setup lang="ts">
 	import { customEndpoint, updateMe } from '@directus/sdk';
+	import { useFormDirty } from '~/composables/useFormDirty';
 	import { useAuth } from '~/store/auth';
 	import { sendErrorToast, sendToast } from '~/utils/send-toast';
 
@@ -199,6 +200,24 @@
 	const publicProbes = ref(user.value.public_probes);
 	const defaultPrefix = ref(user.value.default_prefix);
 	const adoptionToken = ref(user.value.adoption_token);
+
+	useFormDirty({
+		firstName: user.value.first_name,
+		lastName: user.value.last_name,
+		appearance: user.value.appearance,
+		email: user.value.email,
+		publicProbes: user.value.public_probes,
+		defaultPrefix: user.value.default_prefix,
+		adoptionToken: user.value.adoption_token,
+	}, (current) => {
+		return firstName.value !== current.firstName
+			|| lastName.value !== current.lastName
+			|| appearance.value !== current.appearance
+			|| email.value !== current.email
+			|| publicProbes.value !== current.publicProbes
+			|| defaultPrefix.value !== current.defaultPrefix
+			|| adoptionToken.value !== current.adoptionToken;
+	});
 
 	const themeOptions = [
 		{ name: 'Auto', value: null, icon: 'pi pi-cog' },

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -201,7 +201,7 @@
 	const defaultPrefix = ref(user.value.default_prefix);
 	const adoptionToken = ref(user.value.adoption_token);
 
-	useFormDirty({
+	const resetFormDirty = useFormDirty({
 		firstName: user.value.first_name,
 		lastName: user.value.last_name,
 		appearance: user.value.appearance,
@@ -248,6 +248,7 @@
 			await auth.refresh();
 
 			sendToast('success', 'Saved', 'All settings saved');
+			resetFormDirty();
 		} catch (e) {
 			sendErrorToast(e);
 		}


### PR DESCRIPTION
Closes #67 

I added `useFormDirty` composable that can be used in any page, it accepts default form value and a function to check current values against the default values and if the function returns true, `NavigationGuard` which is added in default layout will pick up in the provided state and show a dialog when possible (due to browser `beforeunload` limitations, when navigating to another website or reloading the page, browser alert is shown. otherwise `GPDialog` is used.)