### PR TITLE
feat: remove double fetch of a probe update

### DIFF
--- a/components/ProbeAdoptedContent.vue
+++ b/components/ProbeAdoptedContent.vue
@@ -6,9 +6,13 @@
 				Congratulations!
 			</p>
 			<p class="mt-4">You are now the owner of the following {{ pluralize('probe', probes.length) }}:</p>
-			<div v-for="probe in probes" :key="probe.id" class="mt-4 rounded-xl border bg-surface-0 p-3 dark:border-dark-400 dark:bg-dark-800">
-				<p class="flex items-center justify-center font-bold"><CountryFlag :country="probe.country" size="small"/><span class="ml-2">{{ probe.city }}</span></p>
-				<p>{{ probe.network }}</p>
+			<div v-for="probe in probes" :key="probe.id" class="mt-4">
+				<NuxtLink :to="`/probes/${probe.id}`">
+					<div class="rounded-xl border bg-surface-0 p-3 dark:border-dark-400 dark:bg-dark-800">
+						<p class="flex items-center justify-center font-bold"><CountryFlag :country="probe.country" size="small"/><span class="ml-2">{{ probe.city }}</span></p>
+						<p>{{ probe.network }}</p>
+					</div>
+				</NuxtLink>
 			</div>
 		</div>
 

--- a/components/probe/LocationInput.vue
+++ b/components/probe/LocationInput.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-	import { readItem, updateItem } from '@directus/sdk';
+	import { updateItem } from '@directus/sdk';
 	import isEqual from 'lodash/isEqual';
 	import type { SelectChangeEvent } from 'primevue/select';
 	import CountryFlag from 'vue-country-flag-next';
@@ -260,8 +260,7 @@
 		}
 
 		try {
-			await $directus.request(updateItem('gp_probes', probe.value.id, updProbePart));
-			const updProbeDetails = await $directus.request<Probe>(readItem('gp_probes', probe.value.id));
+			const updProbeDetails = await $directus.request(updateItem('gp_probes', probe.value.id, updProbePart));
 
 			sendToast('success', 'Done', 'The probe has been successfully updated');
 			cancelCityEditing(false);


### PR DESCRIPTION
In https://github.com/jsdelivr/globalping-dash-directus/pull/118, all probe updates happen inside the filter. This means that a fully updated probe is returned on the first request.