### PR TITLE
build: add e2e scripts to package.json

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,33 +30,12 @@ jobs:
           CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }} 
         run: |
           echo "Current branch: $CURRENT_BRANCH."
-          git clone -b $CURRENT_BRANCH https://github.com/jsdelivr/globalping-dash-directus.git test/e2e/globalping-dash-directus || git clone https://github.com/jsdelivr/globalping-dash-directus.git test/e2e/globalping-dash-directus
-
-      - name: Install globalping-dash-directus dependencies
-        working-directory: ./test/e2e/globalping-dash-directus
-        run: |
-          pnpm i
-          pnpm exec playwright install --with-deps chromium
-
-      - name: Prepare .env files
-        working-directory: ./test/e2e/globalping-dash-directus
-        run: |
-          cp .env.e2e.example .env.e2e
-          cp .env.example .env
-          perl -pi -e 's/DASH_INDEX_FILE_PATH=.*/DASH_INDEX_FILE_PATH=..\/..\/..\/.output\/server\/index.mjs/' .env
-
-      - name: Build globalping-dash-directus
-        working-directory: ./test/e2e/globalping-dash-directus
-        run: |
-          docker compose -f docker-compose.e2e.yml up --build -d
-          pnpm run init:e2e
-          docker compose -f docker-compose.e2e.yml stop
+          pnpm run test:e2e:build:directus
 
       - name: Build globalping-dash
         run: |
-          npx dotenv -e test/e2e/globalping-dash-directus/.env -- pnpm build
+          pnpm run test:e2e:build:dash
 
       - name: Run tests
-        working-directory: ./test/e2e/globalping-dash-directus
         run: |
           pnpm run test:e2e:run

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
 		"lint:js:fix": "eslint --cache --max-warnings=0 --fix .",
 		"preview": "nuxt preview",
 		"postinstall": "nuxt prepare",
-		"prepare": "husky || echo 'Failed to install husky'"
+		"prepare": "husky || echo 'Failed to install husky'",
+		"test:e2e": "pnpm run test:e2e:build:directus && pnpm run test:e2e:build:dash && pnpm run test:e2e:run",
+		"test:e2e:build:directus": "./scripts/build-directus.sh",
+		"test:e2e:build:dash": "npx dotenv -e test/e2e/globalping-dash-directus/.env -- pnpm build",
+		"test:e2e:run": "cd test/e2e/globalping-dash-directus; pnpm exec playwright test --grep-invert='.*generate-test\\.spec\\.ts' || E=$?; cd ../../../; exit $E;"
 	},
 	"dependencies": {
 		"@directus/sdk": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"prepare": "husky || echo 'Failed to install husky'",
 		"test:e2e": "pnpm run test:e2e:build:directus && pnpm run test:e2e:build:dash && pnpm run test:e2e:run",
 		"test:e2e:build:directus": "./scripts/build-directus.sh",
-		"test:e2e:build:dash": "npx dotenv -e test/e2e/globalping-dash-directus/.env -- pnpm build",
+		"test:e2e:build:dash": "dotenv -e test/e2e/globalping-dash-directus/.env -- pnpm build",
 		"test:e2e:run": "cd test/e2e/globalping-dash-directus; pnpm exec playwright test --grep-invert='.*generate-test\\.spec\\.ts' || E=$?; cd ../../../; exit $E;"
 	},
 	"dependencies": {

--- a/scripts/build-directus.sh
+++ b/scripts/build-directus.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+CURRENT_BRANCH=${CURRENT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+
+# Checkout and sync the branch if the directory exists, otherwise clone the repository
+if [ -d "test/e2e/globalping-dash-directus" ]; then
+	cd test/e2e/globalping-dash-directus || exit
+	git add .
+	git reset --hard "@{u}"
+	git fetch
+	git checkout "$CURRENT_BRANCH" || git checkout master
+	git reset --hard "@{u}"
+else
+	git clone -b "$CURRENT_BRANCH" https://github.com/jsdelivr/globalping-dash-directus.git test/e2e/globalping-dash-directus || git clone https://github.com/jsdelivr/globalping-dash-directus.git test/e2e/globalping-dash-directus
+	cd test/e2e/globalping-dash-directus || exit
+fi
+
+# Install globalping-dash-directus dependencies
+pnpm i
+pnpm exec playwright install --with-deps chromium
+
+# Prepare .env files
+cp .env.e2e.example .env.e2e
+cp .env.example .env
+perl -pi -e 's/DASH_INDEX_FILE_PATH=.*/DASH_INDEX_FILE_PATH=..\/..\/..\/.output\/server\/index.mjs/' .env
+
+# Build globalping-dash-directus
+docker compose -f docker-compose.e2e.yml up --build -d
+pnpm run init:e2e
+docker compose -f docker-compose.e2e.yml stop
+
+cd ../../../ || exit


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-dash/issues/104

Values from https://github.com/jsdelivr/globalping-dash-directus/blob/master/.env.e2e.example and https://github.com/jsdelivr/globalping-dash-directus/blob/master/.env.example are working fine for local e2e run on mac. But if it is not working on windows and we need a way to set custom values - let me know.