### PR TITLE
fix: catch setMetadata error on the login page

### DIFF
--- a/app/components/gp-dialog/content/AddCredits.vue
+++ b/app/components/gp-dialog/content/AddCredits.vue
@@ -173,6 +173,7 @@
 	const auth = useAuth();
 	const { user } = storeToRefs(auth);
 	const metadata = useMetadata();
+	const { creditsPerAdoptedProbe, creditsPerDollar } = storeToRefs(metadata);
 	const { getUserFilter } = useUserFilter();
 
 	defineEmits([ 'cancel', 'adopt-a-probe' ]);
@@ -198,9 +199,6 @@
 			: Promise.resolve({ bonus: 0, donatedInLastYear: 0, donatedByMonth: [] }),
 		{ default: () => ({ bonus: 0, donatedInLastYear: 0, donatedByMonth: [] }) },
 	);
-
-	const creditsPerAdoptedProbe = metadata.creditsPerAdoptedProbe;
-	const creditsPerDollar = metadata.creditsPerDollar;
 
 	const step1Completed = computed(() => auth.isLoggedIn);
 	const step2Completed = computed(() => adoptionsExists.value);

--- a/app/components/gp-dialog/content/AddCredits.vue
+++ b/app/components/gp-dialog/content/AddCredits.vue
@@ -148,7 +148,7 @@
 						</NuxtLink>
 					</div>
 					<div class="ml-1.5 border-l-2 border-l-primary bg-white p-3 pl-4 dark:bg-dark-700">
-						The base reward is 4000 credits per $1 donated, with up to a 1500% bonus based on your donation history.
+						The base reward is {{creditsPerDollar}} credits per $1 donated, with up to a 1500% bonus based on your donation history.
 						<span v-if="sponsorshipDetails.bonus">You currently receive a {{sponsorshipDetails.bonus}}% bonus.</span>
 					</div>
 				</div>

--- a/app/constants/routes.ts
+++ b/app/constants/routes.ts
@@ -1,0 +1,3 @@
+export const PUBLIC_ROUTES = [
+	'/emails/unsubscribe',
+];

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,8 +1,5 @@
+import { PUBLIC_ROUTES } from '~/constants/routes';
 import { useAuth } from '~/store/auth';
-
-export const PUBLIC_ROUTES = [
-	'/emails/unsubscribe',
-];
 
 export default defineNuxtRouteMiddleware(async (to) => {
 	const auth = useAuth();

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,6 +1,6 @@
 import { useAuth } from '~/store/auth';
 
-const PUBLIC_ROUTES = [
+export const PUBLIC_ROUTES = [
 	'/emails/unsubscribe',
 ];
 

--- a/app/plugins/05.setMetadata.ts
+++ b/app/plugins/05.setMetadata.ts
@@ -1,8 +1,7 @@
 import { customEndpoint } from '@directus/sdk';
+import { PUBLIC_ROUTES } from '~/middleware/auth.global';
 import { useAuth } from '~/store/auth';
 import { useMetadata } from '~/store/metadata';
-
-const INFO_PAGES = [ 'emails', 'authorize' ];
 
 export default defineNuxtPlugin(async () => {
 	const auth = useAuth();
@@ -14,7 +13,8 @@ export default defineNuxtPlugin(async () => {
 		const response = await $directus.request<Metadata>(customEndpoint({ method: 'GET', path: '/metadata' }));
 		metadata.setMetadata(response);
 	} catch (error) {
-		if (!auth.isLoggedIn && !INFO_PAGES.some(page => (route.name as string).startsWith(page))) {
+		// avoid throwing on login redirects to prevent Google from indexing an "error 500" page
+		if (!auth.isLoggedIn && !PUBLIC_ROUTES.includes(route.path)) {
 			return;
 		}
 

--- a/app/plugins/05.setMetadata.ts
+++ b/app/plugins/05.setMetadata.ts
@@ -1,4 +1,3 @@
-import { customEndpoint } from '@directus/sdk';
 import { PUBLIC_ROUTES } from '~/constants/routes';
 import { useAuth } from '~/store/auth';
 import { useMetadata } from '~/store/metadata';
@@ -7,10 +6,9 @@ export default defineNuxtPlugin(async () => {
 	const auth = useAuth();
 	const route = useRoute();
 	const metadata = useMetadata();
-	const { $directus } = useNuxtApp();
 
 	try {
-		const response = await $directus.request<Metadata>(customEndpoint({ method: 'GET', path: '/metadata' }));
+		const response = await $fetch<Metadata>('/api/metadata');
 		metadata.setMetadata(response);
 	} catch (error) {
 		// avoid throwing on login redirects to prevent Google from indexing an "error 500" page

--- a/app/plugins/05.setMetadata.ts
+++ b/app/plugins/05.setMetadata.ts
@@ -1,10 +1,23 @@
 import { customEndpoint } from '@directus/sdk';
+import { useAuth } from '~/store/auth';
 import { useMetadata } from '~/store/metadata';
 
+const INFO_PAGES = [ 'emails', 'authorize' ];
+
 export default defineNuxtPlugin(async () => {
+	const auth = useAuth();
+	const route = useRoute();
 	const metadata = useMetadata();
 	const { $directus } = useNuxtApp();
 
-	const response = await $directus.request<Metadata>(customEndpoint({ method: 'GET', path: '/metadata' }));
-	metadata.setMetadata(response);
+	try {
+		const response = await $directus.request<Metadata>(customEndpoint({ method: 'GET', path: '/metadata' }));
+		metadata.setMetadata(response);
+	} catch (error) {
+		if (!auth.isLoggedIn && !INFO_PAGES.some(page => (route.name as string).startsWith(page))) {
+			return;
+		}
+
+		throw error;
+	}
 });

--- a/app/plugins/05.setMetadata.ts
+++ b/app/plugins/05.setMetadata.ts
@@ -1,5 +1,5 @@
 import { customEndpoint } from '@directus/sdk';
-import { PUBLIC_ROUTES } from '~/middleware/auth.global';
+import { PUBLIC_ROUTES } from '~/constants/routes';
 import { useAuth } from '~/store/auth';
 import { useMetadata } from '~/store/metadata';
 

--- a/app/presets/aura/index.js
+++ b/app/presets/aura/index.js
@@ -95,7 +95,6 @@ import tieredmenu from './tieredmenu';
 import toast from './toast';
 import togglebutton from './togglebutton';
 import toggleswitch from './toggleswitch';
-// import toolbar from './toolbar';
 import tooltip from './tooltip';
 import tree from './tree';
 import treeselect from './treeselect';
@@ -167,7 +166,7 @@ export default {
 	// card,
 	tabview,
 	divider,
-	toolbar,
+	// toolbar,
 	// scrollpanel,
 	// splitter,
 	// splitterpanel,
@@ -189,7 +188,7 @@ export default {
 	// menu
 	// contextmenu,
 	// menu,
-	menubar,
+	// menubar,
 	steps,
 	tieredmenu,
 	// breadcrumb,

--- a/server/api/metadata.get.ts
+++ b/server/api/metadata.get.ts
@@ -1,7 +1,10 @@
 export default defineCachedEventHandler(async (event) => {
 	const config = useRuntimeConfig(event);
 
-	return $fetch<Metadata>(`${config.public.directusUrl}/metadata`);
+	return $fetch<Metadata>(`${config.public.directusUrl}/metadata`, {
+		retry: 1,
+		timeout: 5000,
+	});
 }, {
 	maxAge: 60,
 	name: 'directus-metadata',

--- a/server/api/metadata.get.ts
+++ b/server/api/metadata.get.ts
@@ -1,0 +1,9 @@
+export default defineCachedEventHandler(async (event) => {
+	const config = useRuntimeConfig(event);
+
+	return $fetch<Metadata>(`${config.public.directusUrl}/metadata`);
+}, {
+	maxAge: 60,
+	name: 'directus-metadata',
+	getKey: () => 'directus-metadata',
+});


### PR DESCRIPTION
As discussed on Slack; fixes the issue below. We need to catch the error whenever the user would be redirected to the login page.

<img width="674" height="187" alt="image" src="https://github.com/user-attachments/assets/d55acefd-2da4-4159-a7e0-1cb62a15d4bb" />
